### PR TITLE
Fix broken links in footer

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -10,12 +10,12 @@ const React = require('react');
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
+    return `${baseUrl}docs/${doc}`;
   }
 
   pageUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + (language ? language + '/' : '') + doc;
+    return `${baseUrl}${doc}`;
   }
 
   render() {


### PR DESCRIPTION
This PR fixes the broken "Getting Started" and "Microkubes Manual" links that are in the footer when accessed from the Docs page.